### PR TITLE
Split build architectures

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -23,7 +23,7 @@ jobs:
         id: snapcraft
       - name: Install rabbitmq-server snap
         run: |
-          sudo snap install --devmode ./rabbitmq-server-snap_3.6.10_multi.snap
+          sudo snap install --devmode ./rabbitmq-server-snap_3.6.10_amd64.snap
       - name: Wait for rabbitmq-server to start
         run: |
           set -e -u -x

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,18 @@ contact: https://github.com/nicolasbock/rabbitmq-server-snap/issues
 icon: assets/logo.png
 license: Apache-2.0
 architectures:
-  - build-on: [amd64, i386, arm64]
+  - build-on: [amd64]
+    run-on: [amd64]
+  - build-on: [i386]
+    run-on: [i386]
+  - build-on: [arm64]
+    run-on: [arm64]
+  - build-on: [armhf]
+    run-on: [armhf]
+  - build-on: [ppc64el]
+    run-on: [ppc64el]
+  - build-on: [s390x]
+    run-on: [s390x]
 grade: stable
 confinement: strict
 


### PR DESCRIPTION
Ensure that the snap is built on the architecture it is supposed to run on. No
cross-compiling.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>