### PR TITLE
Expand on architectures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,11 +13,16 @@ contact: https://github.com/nicolasbock/rabbitmq-server-snap/issues
 icon: assets/logo.png
 license: Apache-2.0
 architectures:
-  - arm64
-  - armhf
-  - amd64
-  - ppc64el
-  - s390x
+  - build-on:  arm64
+    build-for: arm64
+  - build-on:  armhf
+    build-for: armhf
+  - build-on:  amd64
+    build-for: amd64
+  - build-on:  ppc64el
+    build-for: ppc64el
+  - build-on:  s390x
+    build-for: s390x
 grade: stable
 confinement: strict
 


### PR DESCRIPTION
Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>