### PR TITLE
Bump Erlang to `OPT-24.3.4.3`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -128,7 +128,7 @@ parts:
   erlang:
     plugin: autotools
     source: https://github.com/erlang/otp.git
-    source-tag: OTP-24.3.4.2
+    source-tag: OTP-24.3.4.3
     source-depth: 1
     build-packages:
       - autoconf


### PR DESCRIPTION
Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>