### PR TITLE
Start "multi-version" in `main`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,7 @@
 name: rabbitmq-server-snap
-base: core22
-version: '3.8.35'
+base: core20
+# version: '3.8.35'
+version: '3.6.16' # 3.6.x
 summary: AMQP server written in Erlang
 description: |
   RabbitMQ is an implementation of AMQP, the emerging standard for
@@ -57,7 +58,8 @@ parts:
       - elixir
       - erlang
     plugin: make
-    source: https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.8.35/rabbitmq-server-3.8.35.tar.xz
+    # source: https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.8.35/rabbitmq-server-3.8.35.tar.xz
+    source: https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v3_6_16/rabbitmq-server_3.6.16.orig.tar.xz # 3.6.x
     build-packages:
       - curl
       - python3-simplejson
@@ -102,7 +104,8 @@ parts:
       - erlang
     plugin: make
     source: https://github.com/elixir-lang/elixir.git
-    source-tag: v1.13.4
+    # source-tag: v1.13.4
+    source-tag: v1.9.4 # 3.6.x
     source-depth: 1
     make-parameters:
       - test
@@ -122,7 +125,8 @@ parts:
   erlang:
     plugin: autotools
     source: https://github.com/erlang/otp.git
-    source-tag: OTP-24.3.4.3
+    # source-tag: OTP-24.3.4.3
+    source-tag: OTP-20.3.8.26 # 3.6.x
     source-depth: 1
     build-packages:
       - fop


### PR DESCRIPTION
Since snapcraft.io does not seem to support branches this change puts all of the different tracks into one `snapcraft.yaml`.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>